### PR TITLE
Add option to only read in part of the ensemble vertical dimension

### DIFF
--- a/README_inputs.md
+++ b/README_inputs.md
@@ -8,6 +8,7 @@ The inputs for `ceilometer_obs_enkf.py` come from a single YAML file. An example
 - **fix_file**: File containing the cell latitude and longitude information (only needed when using MPAS netCDF files).
 - **type**: Ensemble file type. Only fully functioning option at the moment is 'mpas'.
 - **nmem**: Number of ensemble members.
+- **n_zlvl**: Number of vertical levels starting from the surface to read from the ensemble members (omit to read all vertical levels). E.g., to only use the 10 lowest model levels, set `n_zlvl: 10`.
 - **verbose**: Verbosity level for ensemble I/O. Larger numbers result in more output being printed as the program runs.
 
 ## Observation Information

--- a/ceilometer_obs_enkf.py
+++ b/ceilometer_obs_enkf.py
@@ -68,13 +68,17 @@ def read_ensemble(param):
     if (param['ens']['type'] == 'upp'):
         print('\nWarning: UPP output has not been extensively tested yet\n')
 
+    if 'k_end' not in list(param['ens'].keys()):
+        param['ens']['k_end'] = None
+
     fnames = [param['ens']['in_path'].format(num=n) for n in range(1, param['ens']['nmem'] + 1)]
     ens_obj = ens_io.read_ens(fnames,
                               state_fields=param['DA']['state_vars'],
                               other_fields={},
                               verbose=param['ens']['verbose'],
                               fix_fname=param['ens']['fix_file'],
-                              ftype=param['ens']['type'])
+                              ftype=param['ens']['type'],
+                              k_end=param['ens']['k_end'])
 
     return ens_obj
 

--- a/ceilometer_obs_enkf.py
+++ b/ceilometer_obs_enkf.py
@@ -68,8 +68,8 @@ def read_ensemble(param):
     if (param['ens']['type'] == 'upp'):
         print('\nWarning: UPP output has not been extensively tested yet\n')
 
-    if 'k_end' not in list(param['ens'].keys()):
-        param['ens']['k_end'] = None
+    if 'n_zlvl' not in list(param['ens'].keys()):
+        param['ens']['n_zlvl'] = None
 
     fnames = [param['ens']['in_path'].format(num=n) for n in range(1, param['ens']['nmem'] + 1)]
     ens_obj = ens_io.read_ens(fnames,
@@ -78,7 +78,7 @@ def read_ensemble(param):
                               verbose=param['ens']['verbose'],
                               fix_fname=param['ens']['fix_file'],
                               ftype=param['ens']['type'],
-                              k_end=param['ens']['k_end'])
+                              k_end=param['ens']['n_zlvl'])
 
     return ens_obj
 

--- a/main/ens_io.py
+++ b/main/ens_io.py
@@ -113,6 +113,7 @@ class ens_data():
 
         """
 
+        Nz = self.meta['Nz']
         for i, (in_f, out_f) in enumerate(zip(in_fnames, out_fnames)):
             if (in_f == out_f):
                 ds = xr.open_dataset(in_f, mode='a')
@@ -122,7 +123,7 @@ class ens_data():
             for v in self.varnames:
                 data = model_dict[v]
                 if v == 'cldfrac': data = data * 0.01
-                ds[v].values = np.expand_dims(data, axis=0)
+                ds[v][:, :, :Nz].values = np.expand_dims(data, axis=0)
             if (in_f == out_f):
                 ds.to_netcdf(out_f, mode='a')
             else:
@@ -133,6 +134,7 @@ def read_parse_mpas(fnames,
                     fix_fname, 
                     state_fields=['theta', 'qv', 'cldfrac'], 
                     other_fields={}, 
+                    k_end=None,
                     verbose=0):
     """
     Read and parse MPAS netCDF input
@@ -149,6 +151,8 @@ def read_parse_mpas(fnames,
     other_fields : dictionary, optional
         Other fields to extract (can have any dimensions). Key is MPAS field name, value is the 
         general name for the field
+    k_end : integer or None, optional
+        Max index in the vertical dimension (on mass grid). Set to None to not use.
     verbose : int, optional
         Verbosity level
 
@@ -162,9 +166,11 @@ def read_parse_mpas(fnames,
     # Read in mesh info
     if verbose > 0: print('  Reading MPAS mesh information')
     fix_ds = xr.open_dataset(fix_fname)
+    if k_end is None:
+        k_end = fix_ds['zgrid'].shape[1] - 2
     loc = {'lat': np.rad2deg(fix_ds['latCell'].values),
            'lon': np.rad2deg(fix_ds['lonCell'].values) - 360,
-           'hgt': (0.5*(fix_ds['zgrid'][:, 1:] + fix_ds['zgrid'][:, :-1]) - fix_ds['ter']).values}
+           'hgt': (0.5*(fix_ds['zgrid'][:, 1:(k_end+2)] + fix_ds['zgrid'][:, :(k_end+1)]) - fix_ds['ter']).values}
 
     # Read in ensemble data
     if verbose > 0: print('  Reading MPAS mesh atmospheric information')
@@ -179,9 +185,9 @@ def read_parse_mpas(fnames,
         idx = 0
         for v in state_fields:
             if v == 'cldfrac':
-                data = ds[v].values * 100
+                data = ds[v][:, :, :(k_end+1)].values * 100
             else:
-                data = ds[v].values
+                data = ds[v][:, :, :(k_end+1)].values
             state[idx:(idx+N3d), i] = np.ravel(data)
             idx = idx + N3d
         for key in other_fields.keys():
@@ -261,7 +267,8 @@ def read_ens(fnames,
              other_fields={}, 
              verbose=0, 
              fix_fname=None, 
-             ftype='mpas'):
+             ftype='mpas',
+             k_end=None):
     """
     Read ensemble output
 
@@ -280,6 +287,9 @@ def read_ens(fnames,
         File containing grid or mesh information. Only needed for MPAS output
     ftype : string, optional
         Input file type. Options: 'mpas' or 'upp'
+    k_end : integer or None, optional
+        Max index in the vertical dimension (on mass grid). Set to None to not use.
+        Only available for ftype = 'mpas'.
     
     Returns
     -------
@@ -293,8 +303,12 @@ def read_ens(fnames,
                                   fix_fname, 
                                   state_fields=state_fields, 
                                   other_fields=other_fields,
+                                  k_end=k_end,
                                   verbose=verbose)
     elif ftype == 'upp':
+        if k_end is not None:
+            raise ValueError("If ftype = 'upp', then k_end must be None")
+
         ens_obj = read_parse_upp(fnames,
                                  state_fields=state_fields, 
                                  other_fields=other_fields,

--- a/main/ens_io.py
+++ b/main/ens_io.py
@@ -80,7 +80,6 @@ class ens_data():
         N2d = self.meta['N2d']
         Nz = self.meta['Nz']
         N3d = N2d * Nz
-        print(f"N3d = {N3d}")
 
         # State variables
         for i, v in enumerate(self.varnames):
@@ -182,7 +181,7 @@ def read_parse_mpas(fnames,
     N3d = loc['hgt'].size
     Nens = len(fnames)
     state = np.zeros((N3d * len(state_fields), Nens))
-    if verbose > 0: print(f"  MPAS mesh size = {N3d}")
+    if verbose > 0: print(f"  MPAS domain size = {N3d}")
     if verbose > 0: print('  Reading MPAS mesh atmospheric information')
     other = {}
     for key in other_fields.keys():

--- a/main/ens_io.py
+++ b/main/ens_io.py
@@ -80,6 +80,7 @@ class ens_data():
         N2d = self.meta['N2d']
         Nz = self.meta['Nz']
         N3d = N2d * Nz
+        print(f"N3d = {N3d}")
 
         # State variables
         for i, v in enumerate(self.varnames):
@@ -121,9 +122,10 @@ class ens_data():
                 ds = xr.open_dataset(in_f)
             model_dict = self.var_dict(i)
             for v in self.varnames:
-                data = model_dict[v]
+                data = np.expand_dims(model_dict[v], axis=0)
                 if v == 'cldfrac': data = data * 0.01
-                ds[v][:, :, :Nz].values = np.expand_dims(data, axis=0)
+                # Order here matters. Data is not written if indices are before .values
+                ds[v].values[:, :, :Nz] = data
             if (in_f == out_f):
                 ds.to_netcdf(out_f, mode='a')
             else:
@@ -196,8 +198,10 @@ def read_parse_mpas(fnames,
             state[idx:(idx+N3d), i] = np.ravel(data)
             idx = idx + N3d
         for key in other_fields.keys():
-            other[other_fields[key]].append(np.ravel(ds[key].values))
-    
+            other[other_fields[key]].append(np.ravel(ds[key][:, :, :k_end].values))
+   
+    ds.close()
+
     # Convert other output into arrays
     for key in other_fields.keys():
         name = other_fields[key]

--- a/main/ens_io.py
+++ b/main/ens_io.py
@@ -153,6 +153,8 @@ def read_parse_mpas(fnames,
         general name for the field
     k_end : integer or None, optional
         Max index in the vertical dimension (on mass grid). Set to None to not use.
+        Conventions follow Python indexing conventions (start at 0, with k_end not included).
+        I.e., Number of vertical levels to keep, starting at the surface
     verbose : int, optional
         Verbosity level
 
@@ -164,19 +166,22 @@ def read_parse_mpas(fnames,
     """
 
     # Read in mesh info
+    # Need the -1 if k_end = None b/c zgrid has a vertical dimension = nlvl in the mass grid + 1
+    # I.e., zgrid gives the height of the levels between the mass grid layers
     if verbose > 0: print('  Reading MPAS mesh information')
     fix_ds = xr.open_dataset(fix_fname)
     if k_end is None:
-        k_end = fix_ds['zgrid'].shape[1] - 2
+        k_end = fix_ds['zgrid'].shape[1] - 1
     loc = {'lat': np.rad2deg(fix_ds['latCell'].values),
            'lon': np.rad2deg(fix_ds['lonCell'].values) - 360,
-           'hgt': (0.5*(fix_ds['zgrid'][:, 1:(k_end+2)] + fix_ds['zgrid'][:, :(k_end+1)]) - fix_ds['ter']).values}
+           'hgt': (0.5*(fix_ds['zgrid'][:, 1:(k_end+1)] + fix_ds['zgrid'][:, :(k_end)]) - fix_ds['ter']).values}
 
     # Read in ensemble data
-    if verbose > 0: print('  Reading MPAS mesh atmospheric information')
     N3d = loc['hgt'].size
     Nens = len(fnames)
     state = np.zeros((N3d * len(state_fields), Nens))
+    if verbose > 0: print(f"  MPAS mesh size = {N3d}")
+    if verbose > 0: print('  Reading MPAS mesh atmospheric information')
     other = {}
     for key in other_fields.keys():
         other[other_fields[key]] = []
@@ -185,9 +190,9 @@ def read_parse_mpas(fnames,
         idx = 0
         for v in state_fields:
             if v == 'cldfrac':
-                data = ds[v][:, :, :(k_end+1)].values * 100
+                data = ds[v][:, :, :k_end].values * 100
             else:
-                data = ds[v][:, :, :(k_end+1)].values
+                data = ds[v][:, :, :k_end].values
             state[idx:(idx+N3d), i] = np.ravel(data)
             idx = idx + N3d
         for key in other_fields.keys():

--- a/tests/sample.yml
+++ b/tests/sample.yml
@@ -10,7 +10,7 @@ ens:
   type: 'mpas'
   nmem: 3
   verbose: 1
-  k_end: 2
+  k_end: 3
 
 # Observation Information
 obs:

--- a/tests/sample.yml
+++ b/tests/sample.yml
@@ -10,7 +10,7 @@ ens:
   type: 'mpas'
   nmem: 3
   verbose: 1
-  k_end: 3
+  n_zlvl: 3
 
 # Observation Information
 obs:

--- a/tests/sample.yml
+++ b/tests/sample.yml
@@ -10,6 +10,7 @@ ens:
   type: 'mpas'
   nmem: 3
   verbose: 1
+  k_end: 2
 
 # Observation Information
 obs:

--- a/tests/test_ens_io.py
+++ b/tests/test_ens_io.py
@@ -63,6 +63,7 @@ class TestEnsMPASIO():
         Test the .var_dict() method using MPAS netCDF output
         """
         sample = copy.deepcopy(sample)
+        print(sample.meta)
 
         # Read in mesh info and netCDF output for a single member
         ds_info = xr.open_dataset('./sample_data/mpas/invariant_TEST.nc')
@@ -77,7 +78,7 @@ class TestEnsMPASIO():
                                           ['theta', 'qv', 'cldfrac', 'cld_mass_mix'],
                                           [1, 1, 100, 1]):
             assert np.all(np.isclose(ds[f_origin].values * scale, model_dict[f_new]))
-    
+
 
     def test_write_mpas_out_for_DA(self, sample):
         """
@@ -97,6 +98,8 @@ class TestEnsMPASIO():
 
         # Check output from a sample file
         ds_out = xr.open_dataset(out_fnames[0])
+        print(ds_out['theta'].shape)
+        print(ds_out['theta'][0, 0, :].values)
         assert np.all(np.isclose(ds_out['theta'].values, 0))
         
         # Clean up
@@ -157,6 +160,38 @@ class TestEnsMPASIO():
         # Clean up
         for f in out_fnames:
             os.remove(f)
+
+
+class TestEnsMPASIOKend():
+
+    @pytest.fixture(scope='class')
+    def sample(self):
+        fnames = [f'./sample_data/mpas/mem00{n}/mpasout.2024-05-27_04.00.00.TEST.nc' for n in range(1, 4)]
+        state_fields = ['theta', 'qv', 'cldfrac']
+        other_fields = {'qc' : 'cld_mass_mix'}
+        fix_fname = './sample_data/mpas/invariant_TEST.nc'
+        ftype = 'mpas'
+        k_end = 3
+        return ens_io.read_ens(fnames, 
+                           state_fields=state_fields,
+                           other_fields=other_fields,
+                           fix_fname=fix_fname,
+                           ftype=ftype,
+                           k_end=k_end)
+
+
+    def test_check_subset(self, sample):
+        """
+        Ensure that the ensemble is subset appropriately
+        """
+
+        k_end = 3
+        assert sample.meta['Nz'] == k_end
+
+        #ds = xr.open_dataset('./sample_data/mpas/mem001/mpasout.2024-05-27_04.00.00.TEST.nc')
+        #print(sample.state.shape)
+        #subset_theta = sample.var_dict(0)['theta']
+        #assert np.all(np.isclose(subset_theta, ds['theta'][:, :k_end].values))
 
 
 class TestEnsUPPIO():

--- a/tests/test_ens_io.py
+++ b/tests/test_ens_io.py
@@ -63,7 +63,6 @@ class TestEnsMPASIO():
         Test the .var_dict() method using MPAS netCDF output
         """
         sample = copy.deepcopy(sample)
-        print(sample.meta)
 
         # Read in mesh info and netCDF output for a single member
         ds_info = xr.open_dataset('./sample_data/mpas/invariant_TEST.nc')
@@ -98,8 +97,6 @@ class TestEnsMPASIO():
 
         # Check output from a sample file
         ds_out = xr.open_dataset(out_fnames[0])
-        print(ds_out['theta'].shape)
-        print(ds_out['theta'][0, 0, :].values)
         assert np.all(np.isclose(ds_out['theta'].values, 0))
         
         # Clean up
@@ -188,10 +185,10 @@ class TestEnsMPASIOKend():
         k_end = 3
         assert sample.meta['Nz'] == k_end
 
-        #ds = xr.open_dataset('./sample_data/mpas/mem001/mpasout.2024-05-27_04.00.00.TEST.nc')
-        #print(sample.state.shape)
-        #subset_theta = sample.var_dict(0)['theta']
-        #assert np.all(np.isclose(subset_theta, ds['theta'][:, :k_end].values))
+        ds = xr.open_dataset('./sample_data/mpas/mem001/mpasout.2024-05-27_04.00.00.TEST.nc')
+        print(sample.state.shape)
+        subset_theta = sample.var_dict(0)['theta']
+        assert np.all(np.isclose(subset_theta, ds['theta'][:, :, :k_end].values))
 
 
 class TestEnsUPPIO():

--- a/tests/test_ens_io.py
+++ b/tests/test_ens_io.py
@@ -159,36 +159,39 @@ class TestEnsMPASIO():
             os.remove(f)
 
 
-class TestEnsMPASIOKend():
+    def test_read_parse_mpas_k_end(self, sample):
+        """
+        Test read_parse_mpas() when k_end is not None
 
-    @pytest.fixture(scope='class')
-    def sample(self):
+        Note: In its current form, the order of these tests matters. If this test is before the 
+        test_write_mpas* tests, those tests will fail!
+        """
+
+        sample = copy.deepcopy(sample)
+
+        # Read MPAS data with k_end != None
         fnames = [f'./sample_data/mpas/mem00{n}/mpasout.2024-05-27_04.00.00.TEST.nc' for n in range(1, 4)]
         state_fields = ['theta', 'qv', 'cldfrac']
         other_fields = {'qc' : 'cld_mass_mix'}
         fix_fname = './sample_data/mpas/invariant_TEST.nc'
         ftype = 'mpas'
-        k_end = 3
-        return ens_io.read_ens(fnames, 
-                           state_fields=state_fields,
-                           other_fields=other_fields,
-                           fix_fname=fix_fname,
-                           ftype=ftype,
-                           k_end=k_end)
+        k_end = 2
+        subset_ens = ens_io.read_ens(fnames,
+                                     state_fields=state_fields,
+                                     other_fields=other_fields,
+                                     fix_fname=fix_fname,
+                                     ftype=ftype,
+                                     k_end=k_end)
 
+        # Check size of state
+        assert subset_ens.meta['Nz'] == k_end
+        assert subset_ens.meta['Nz'] < sample.meta['Nz']
+        assert subset_ens.meta['Nx'] < sample.meta['Nx']
 
-    def test_check_subset(self, sample):
-        """
-        Ensure that the ensemble is subset appropriately
-        """
-
-        k_end = 3
-        assert sample.meta['Nz'] == k_end
-
-        ds = xr.open_dataset('./sample_data/mpas/mem001/mpasout.2024-05-27_04.00.00.TEST.nc')
-        print(sample.state.shape)
-        subset_theta = sample.var_dict(0)['theta']
-        assert np.all(np.isclose(subset_theta, ds['theta'][:, :, :k_end].values))
+        # Check that the right subset was extracted
+        theta_subset = subset_ens.var_dict(0)['theta']
+        theta_full = sample.var_dict(0)['theta']
+        assert np.all(np.isclose(theta_subset, theta_full[:, :k_end]))
 
 
 class TestEnsUPPIO():


### PR DESCRIPTION
This PR resolves #2 by adding a YAML parameter, `n_zlvl`, that controls how many vertical levels from the model are read in and used during data assimilation. 

To enable this feature, set `n_zlvl = X` in the `ens` section of the YAML file, where `X` is the number of vertical levels to read in (starting from the surface). If `n_zlvl` is not specified in the YAML file, then the entire model domain is read in and used for data assimilation.

## Testing
- A new automated test was added to `./tests/test_ens_io.py` and all automated tests pass.
- Output from the updated code with `n_zlvl` not specified is identical to the output from the original code (as expected).